### PR TITLE
Updated template creation to make it a bit more powerful

### DIFF
--- a/Sources/ssg/TemplateEdit.swift
+++ b/Sources/ssg/TemplateEdit.swift
@@ -19,7 +19,7 @@ public enum ProjectKeys: CaseIterable {
 private extension ProjectKeys {
     var bytes: [UInt8] {
         switch self {
-        case .keyName: return Self.keyNameScrabbledValue
+        case .keyName: return Self.keyNameScrambledValue
         }
     }
 
@@ -37,7 +37,7 @@ private extension ProjectKeys {
 }
 
 private extension ProjectKeys {
-    static var keyNameScrabbledValue: [UInt8] { [] }
+    static var keyNameScrambledValue: [UInt8] { [] }
 }
 
 private extension ProjectKeys {

--- a/Sources/ssg/TemplateEdit.swift
+++ b/Sources/ssg/TemplateEdit.swift
@@ -1,61 +1,53 @@
 //
-//  File.swift
+//  TemplateEdit.swift
 //  
 //
 //  Created by Norman Barnard on 2/20/21.
 //
 
-import Foundation
 import CryptoKit
+import Foundation
 
 // Use this file for editing the template.
 
-enum ProjectKeys {
+public enum ProjectKeys: CaseIterable {
+    case keyName
 
-    private static var keyData: [UInt8] { [] }
-
-    private static var decryptKey: SymmetricKey? {
-        guard let d = dataFromBase64Encoded(keyData) else { return nil }
-        return SymmetricKey(data: d)
-    }
-
-    private static var keyNameValue: [UInt8] { [] }
-
-    private enum Internal {
-        case keyName
-    }
-
-    public static var keyName: String { reconstituteValue(key: Internal.keyName) }
-
-    private static func reconstituteValue(key: Internal) -> String {
-
-        guard let decryptKey = decryptKey else { fatalError("Missing decryption key!") }
-
-        let bytes: [UInt8] = {
-            switch key {
-            case .keyName:
-                return keyNameValue
-            }
-        }()
-
-        guard
-            let data = dataFromBase64Encoded(bytes),
-            let sealedBox = try? ChaChaPoly.SealedBox(combined: data)
-        else { fatalError() }
-
-        guard
-            let decryptedData = try? ChaChaPoly.open(sealedBox, using: decryptKey),
-            let clearText = String(data: decryptedData, encoding: .utf8)
-        else {
-            fatalError()
-        }
-        return clearText
-    }
-
-    private static func dataFromBase64Encoded(_ bytes: [UInt8]) -> Data? {
-        guard let s = String(bytes: bytes, encoding: .utf8) else { return nil }
-        return Data(base64Encoded: s)
-    }
-
+    public var value: String { reconstitute }
 }
 
+private extension ProjectKeys {
+    var bytes: [UInt8] {
+        switch self {
+        case .keyName: return Self.keyNameScrabbledValue
+        }
+    }
+
+    var reconstitute: String {
+        guard let decryptKey = Self.decryptKey else { fatalError("No Decryption Key") }
+        guard
+            let reconstitutedText = Self.dataFromBase64Encoded(bytes)
+                .flatMap({ try? ChaChaPoly.SealedBox(combined: $0) })
+                .flatMap({ try? ChaChaPoly.open($0, using: decryptKey) })
+                .flatMap({ String(data: $0, encoding: .utf8) })
+        else { fatalError() }
+
+        return reconstitutedText
+    }
+}
+
+private extension ProjectKeys {
+    static var keyNameScrabbledValue: [UInt8] { [] }
+}
+
+private extension ProjectKeys {
+    static var keyData: [UInt8] { [] }
+
+    static var decryptKey: SymmetricKey? {
+        dataFromBase64Encoded(keyData).flatMap { SymmetricKey(data: $0) }
+    }
+
+    static func dataFromBase64Encoded(_ bytes: [UInt8]) -> Data? {
+        String(bytes: bytes, encoding: .utf8).flatMap { Data(base64Encoded: $0) }
+    }
+}

--- a/Sources/ssg/template.swift
+++ b/Sources/ssg/template.swift
@@ -29,7 +29,7 @@ private extension ProjectKeys {
     var bytes: [UInt8] {
         switch self {
         {{#apiKeys}}
-        case .{{keyName}}: return Self.{{keyName}}ScrabbledValue
+        case .{{keyName}}: return Self.{{keyName}}ScrambledValue
         {{/apiKeys}}
         }
     }
@@ -49,7 +49,7 @@ private extension ProjectKeys {
 
 private extension ProjectKeys {
     {{#apiKeys}}
-    static var {{keyName}}ScrabbledValue: [UInt8] { {{keyValue}} }
+    static var {{keyName}}ScrambledValue: [UInt8] { {{keyValue}} }
     {{/apiKeys}}
 }
 

--- a/Sources/ssg/template.swift
+++ b/Sources/ssg/template.swift
@@ -12,67 +12,57 @@ enum Template {
 static let keyFile: String =
 """
 // ****
-// this file was automatically generated. do not edit
+// This file was automatically generated; do not edit.
 //
-// 
-import Foundation
+
 import CryptoKit
 
-enum ProjectKeys {
-
-    private static var keyData: [UInt8] { {{encryptionKey}} }
-
-    private static var decryptKey: SymmetricKey? {
-        guard let d = dataFromBase64Encoded(keyData) else { return nil }
-        return SymmetricKey(data: d)
-    }
-
+public enum ProjectKeys: CaseIterable {
     {{#apiKeys}}
-    private static var {{keyName}}value: [UInt8] { {{keyValue}} }
+    case {{keyName}}
     {{/apiKeys}}
 
-    private enum Internal {
+    public var value: String { reconstitute }
+}
+
+private extension ProjectKeys {
+    var bytes: [UInt8] {
+        switch self {
         {{#apiKeys}}
-        case {{keyName}}
+        case .{{keyName}}: return Self.{{keyName}}ScrabbledValue
         {{/apiKeys}}
+        }
     }
 
-    {{#apiKeys}}
-    public static var {{keyName}}: String { reconstituteValue(key: Internal.{{keyName}}) }
-    {{/apiKeys}}
-
-    private static func reconstituteValue(key: Internal) -> String {
-
-        guard let decryptKey = decryptKey else { fatalError("No Decryption Key") }
-
-        let bytes: [UInt8] = {
-            switch key {
-                {{#apiKeys}}
-                case .{{keyName}}:
-                return {{keyName}}value
-                {{/apiKeys}}
-            }
-        }()
-
+    var reconstitute: String {
+        guard let decryptKey = Self.decryptKey else { fatalError("No Decryption Key") }
         guard
-            let data = dataFromBase64Encoded(bytes),
-            let sealedBox = try? ChaChaPoly.SealedBox(combined: data)
+            let reconstitutedText = Self.dataFromBase64Encoded(bytes)
+                .flatMap({ try? ChaChaPoly.SealedBox(combined: $0) })
+                .flatMap({ try? ChaChaPoly.open($0, using: decryptKey) })
+                .flatMap({ String(data: $0, encoding: .utf8) })
         else { fatalError() }
 
-        guard
-            let decryptedData = try? ChaChaPoly.open(sealedBox, using: decryptKey),
-            let clearText = String(data: decryptedData, encoding: .utf8)
-        else {
-            fatalError()
-        }
-        return clearText
+        return reconstitutedText
+    }
+}
+
+private extension ProjectKeys {
+    {{#apiKeys}}
+    static var {{keyName}}ScrabbledValue: [UInt8] { {{keyValue}} }
+    {{/apiKeys}}
+}
+
+private extension ProjectKeys {
+    static var keyData: [UInt8] { {{encryptionKey}} }
+
+    static var decryptKey: SymmetricKey? {
+        dataFromBase64Encoded(keyData).flatMap { SymmetricKey(data: $0) }
     }
 
-    private static func dataFromBase64Encoded(_ bytes: [UInt8]) -> Data? {
-        guard let s = String(bytes: bytes, encoding: .utf8) else { return nil }
-        return Data(base64Encoded: s)
+    static func dataFromBase64Encoded(_ bytes: [UInt8]) -> Data? {
+        String(bytes: bytes, encoding: .utf8).flatMap { Data(base64Encoded: $0) }
     }
-
 }
 """
 }


### PR DESCRIPTION
- Removed the `Internal` `enum` and now all of the values are just top-level `case`s.
- Made `ProjectKeys` conform to `CaseIterable`. 
  - This was done because there is a need sometimes to get all of the keys.
    - Example Usecase: Redacting the values in a logger.
- Made `ProjectKeys` `public` so that it is more accessible.
  - Example Usecase: Have the keys being created in Module A, and used in Module A. However, sometimes other modules may need access to some of the keys.