### PR TITLE
Fix - Add Foundation import to template

### DIFF
--- a/Sources/ssg/template.swift
+++ b/Sources/ssg/template.swift
@@ -15,6 +15,7 @@ static let keyFile: String =
 // This file was automatically generated; do not edit.
 //
 
+import Foundation
 import CryptoKit
 
 public enum ProjectKeys: CaseIterable {


### PR DESCRIPTION
Adding the Foundation import back to the template which the generated file needs to use `Data`.